### PR TITLE
Modify run syntax to accept multiple query variables

### DIFF
--- a/minikanren/minikanren.rkt
+++ b/minikanren/minikanren.rkt
@@ -168,7 +168,13 @@
 
 (define-syntax run
   (syntax-rules ()
-    ((_ n (x) g0 g^ ...)
+    ((_ n (x) g ...)
+     (run n x g ...))
+    ((_ n (x0 x ...) g ...)
+     (run n q (fresh (x0 x ...)
+                     (== `(,x0 ,x ...) q) g ...)))
+    
+    ((_ n x g0 g^ ...)
      (take n (lambdaf@ ()
                        (let ((g (fresh (x)
                                   (lambdag@ (s)
@@ -179,7 +185,7 @@
 
 (define-syntax run*
   (syntax-rules ()
-    ((_ (x) g ...) (run #f (x) g ...))))
+    ((_ x g ...) (run #f x g ...))))
 
 (define take
   (lambda (n f)


### PR DESCRIPTION
Fixes #7 

To clarify, so as to not make any breaking changes to previously existing code, singleton lists behave exactly line a single argument:

```racket
(run* (q) (== 'cat q)) ; ->  '(cat)
```
is equivalent to:
```racket
(run* q (== 'cat q)) ; '(cat)
``` 

However, for lists with more than one argument, we nest one more level:

```racket
(run* (a b) (appendo a b '(1 2 3)))
(run* (q)
    (fresh (a b) (== q (list a  b))                      
        (appendo a b '(1 2 3))))
;; both result in: '((() (1 2 3)) ((1) (2 3)) ((1 2) (3)) ((1 2 3) ()))
;; instead of:       '(() (1 2 3)) ((1) (2 3)) ((1 2) (3)) ((1 2 3) ())
```

Let me know what you think!