### PR TITLE
Add `else` for `cond*`, add `condi`, and fix definition of `mplus`.

### DIFF
--- a/minikanren/minikanren.scrbl
+++ b/minikanren/minikanren.scrbl
@@ -6,7 +6,7 @@
 
 @defmodule[minikanren]
 
-An embedding of logic programming in Scheme. 
+An embedding of logic programming in Scheme.
 
 The miniKanren language in this package is the language presented in
 Byrd and Friedman's "From variadic functions to variadic relations"
@@ -30,6 +30,10 @@ Introduces a new goal that unifies two values.
 Introduces a new goal that behaves analagously to @racket[cond].
 }
 
+@defform[(condi ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
+@racket[condi] behaves like @racket[conde], except that its values are interleaved.
+}
+
 @defform[(fresh (x ...) goal_0 goal_1 ...)]{
 Introduces a new logic variable bound to each @racket[_x] in the scope of its
 body, each clause of which should be a goal.
@@ -41,11 +45,11 @@ Finds up to @racket[_n] ways to instantiate the logic variable bound to
 @racket[#f], then run finds all satisfying instantiations for @racket[_x].)
 }
 
-@defthing[succeed]{
+@defform[succeed]{
 It is a goal that succeeds.
 }
 
-@defthing[fail]{
+@defform[fail]{
 It is a goal that fails; it is unsuccessful.
 }
 
@@ -55,10 +59,10 @@ Minikanren also provides the following helpers:
 Equivalent to @racket[(run #f (x) goal_0 goal_1 ...)].
 }
 
-@defform[(conda ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{}
+@defform[(conda ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]
 @defform[(condu ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
 Variants of @racket[conde] that correspond to the committed-choice of Mercury
-and are used in place of Prolog's cut.
+and are used in placb of Prolog's cut.
 }
 
 @defform[(project (x ...) goal_1 goal_2 ...)]{

--- a/minikanren/minikanren.scrbl
+++ b/minikanren/minikanren.scrbl
@@ -26,11 +26,11 @@ only for reference.
 Introduces a new goal that unifies two values.
 }
 
-@defform[(conde ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
+@defform[(conde [goal_1 goal_1a ...] [goal_2 goal_2a ...] ...)]{
 Introduces a new goal that behaves analagously to @racket[cond].
 }
 
-@defform[(condi ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
+@defform[(condi [goal_1 goal_1a ...] [goal_2 goal_2a ...] ...)]{
 @racket[condi] behaves like @racket[conde], except that its values are interleaved.
 }
 
@@ -45,11 +45,11 @@ Finds up to @racket[_n] ways to instantiate the logic variable bound to
 @racket[#f], then run finds all satisfying instantiations for @racket[_x].)
 }
 
-@defform[succeed]{
+@defthing[succeed goal? #:value (== #t #t)]{
 It is a goal that succeeds.
 }
 
-@defform[fail]{
+@defthing[fail goal? #:value (== #t #f)]{
 It is a goal that fails; it is unsuccessful.
 }
 
@@ -59,8 +59,8 @@ Minikanren also provides the following helpers:
 Equivalent to @racket[(run #f (x) goal_0 goal_1 ...)].
 }
 
-@defform[(conda ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]
-@defform[(condu ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
+@deftogether[(@defform[(conda [goal_1 goal_1a ...] [goal_2 goal_2a ...] ...)]
+              @defform[(condu [goal_1 goal_1a ...] [goal_2 goal_2a ...] ...)])]{
 Variants of @racket[conde] that correspond to the committed-choice of Mercury
 and are used in place of Prolog's cut.
 }

--- a/minikanren/minikanren.scrbl
+++ b/minikanren/minikanren.scrbl
@@ -62,7 +62,7 @@ Equivalent to @racket[(run #f (x) goal_0 goal_1 ...)].
 @defform[(conda ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]
 @defform[(condu ((goal_1 goal_1a ...) (goal_2 goal_2a ...) ...))]{
 Variants of @racket[conde] that correspond to the committed-choice of Mercury
-and are used in placb of Prolog's cut.
+and are used in place of Prolog's cut.
 }
 
 @defform[(project (x ...) goal_1 goal_2 ...)]{


### PR DESCRIPTION
On the Appendix A of `The Reasoned Schemer`, `mplus` and `mplusi` are defined like this:
```
(define mplus
  (λ (a-inf f)
    (case-inf a-inf
      (f)
      [(a) (choice a f)]
      [(a f0) (choice a (λf@ () (mplus (f0) f)))])))

(define mplusi
  (λ (a-inf f)
    (case-inf a-inf
      (f)
      [(a) (choice a f)]
      [(a f0) (choice a (λf@ () (mplusi (f) f0)))])))
```

In the old definition, `mplus` was defined as `mplusi`, which made `conde`'s behavior wrong.
For example, running code:
```
(define teacupo
  (λ (x)
    (conde [(== 'tea x) succeed]
           [(== 'cup x) succeed]
           [fail])))
(run* (r)
      (conde [(teacupo r) succeed]
             [(== #f r) succeed]
             [fail]))
```
return `'(#f tea cup)`. The correct result should be `'(tea cup #f)`.


To make `cond*` supports `else` branch, it's better to define themselves recursively.