### PR TITLE
Fix the definitions of `mplusi` and `condi`, add `all` and `alli`.

### DIFF
--- a/minikanren/minikanren.rkt
+++ b/minikanren/minikanren.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (provide succeed fail
-         == fresh conde condi run run*
+         == fresh run run*
+         conde all condi alli
          conda condu project)
 
 
@@ -148,6 +149,17 @@
          (bind* (g0 s) g ...)
          ((conde c ...) s))))]))
 
+(define-syntax all
+  (syntax-rules ()
+    [(_) succeed]
+    [(_ g) g]
+    [(_ g0 g ...)
+     (let ([g^ g0])
+       (lambdag@ (s)
+         (bind (g^ s)
+               (lambdag@ (s)
+                 ((all g ...) s)))))]))
+
 (define-syntax mplus*
   (syntax-rules ()
     [(_ e) e]
@@ -176,6 +188,17 @@
        ((a f) (mplus (g a) (lambdaf@ () (bind (f) g))))
        ((f) (inc (bind (f) g))))))
 
+(define-syntax alli
+  (syntax-rules ()
+    [(_) succeed]
+    [(_ g) g]
+    [(_ g0 g ...)
+     (let ([g^ g0])
+       (lambdag@ (s)
+         (bindi (g^ s)
+                (lambdag@ (s)
+                  ((alli g ...) s)))))]))
+
 (define-syntax condi
   (syntax-rules (else)
     [(_) fail]
@@ -186,7 +209,7 @@
      (lambdag@ (s)
        (inc
         (mplusi*
-         (bindi* (g0 s) g ...)
+         (bind* (g0 s) g ...)
          ((condi c ...) s))))]))
 
 (define-syntax mplusi*
@@ -200,7 +223,7 @@
        (f)
        ((a) (choice a f))
        ((a f^) (choice a (lambdaf@ () (mplusi (f) f^))))
-       ((f^) (inc (mplusi (f) f^))))))
+       ((f^) (inc (mplusi (f^) f))))))
 
 (define-syntax bindi*
   (syntax-rules ()

--- a/minikanren/minikanren.scrbl
+++ b/minikanren/minikanren.scrbl
@@ -30,8 +30,16 @@ Introduces a new goal that unifies two values.
 Introduces a new goal that behaves analagously to @racket[cond].
 }
 
+@defform[(all goal_0 goal_1 ...)]{
+The goals of an all must succeed for the all to succeed.
+}
+
 @defform[(condi [goal_1 goal_1a ...] [goal_2 goal_2a ...] ...)]{
 @racket[condi] behaves like @racket[conde], except that its values are interleaved.
+}
+
+@defform[(alli goal_0 goal_1 ...)]{
+@racket[alli] behaves like @racket[all], except that its values are interleaved.
 }
 
 @defform[(fresh (x ...) goal_0 goal_1 ...)]{


### PR DESCRIPTION
On the Appendix A of `The Reasoned Schemer`, `ifi` is defined like this:
```
(define-syntax ifi
  (syntax-rules ()
    [(_ g0 g1 g2)
     (λg@ (s)
       (mplusi ((all g0 g1) s) (λf@ () (g2 s))))]))

```

Because `mplusi` will merge 2 streams interleaved, it just need `all` to append `g0` and `g1` instead of `alli`.

So in the definition of `condi`, I think we should use `bind*` instead of `bindi*` for the same reason.

In the definition of `mplusi`, when `a-inf` is a λf, we shouldn't change the order of f^ and f, otherwise the following BUG will appear:
```
> (define anyo
    (λ (g)
      (conde [g succeed]
             [else (anyo g)])))
  (define nevero  (anyo fail))
  (define alwayso (anyo succeed))
> (run 5 (q)
     (alli (conde [succeed succeed]
                  [else nevero])
           alwayso)
     (== #t q))
'(#t #t #t #t #t)
```
It should have no value instead of returning `'(#t #t #t #t #t)`